### PR TITLE
Add callback events for download and print

### DIFF
--- a/packages/udoc-viewer/src/UDocViewer.ts
+++ b/packages/udoc-viewer/src/UDocViewer.ts
@@ -146,6 +146,9 @@ export interface ViewerEventMap {
     "document:load": { pageCount: number };
     "document:close": Record<string, never>;
     "download:progress": DownloadProgress;
+    download: { filename: string };
+    /** Fires on the actual print, not when the print dialog opens. */
+    print: { pageCount: number };
     error: { error: Error; phase: "fetch" | "parse" | "render" };
     "page:change": { page: number; previousPage: number };
     "ui:visibilityChange": { component: UIComponent; visible: boolean };
@@ -1918,12 +1921,14 @@ export class UDocViewer {
         const blob = new Blob([bytes.buffer as ArrayBuffer], { type: mimeType });
         const url = URL.createObjectURL(blob);
 
+        const resolvedFilename = filename ?? this.getDefaultFilename();
         const a = document.createElement("a");
         a.href = url;
-        a.download = filename ?? this.getDefaultFilename();
+        a.download = resolvedFilename;
         a.click();
 
         URL.revokeObjectURL(url);
+        this.emit("download", { filename: resolvedFilename });
     }
 
     /**
@@ -1942,6 +1947,8 @@ export class UDocViewer {
 
         const pageIndices = this.resolvePageIndices(options.pageRange);
         const isAllPages = pageIndices.length === this._pageCount;
+
+        this.emit("print", { pageCount: pageIndices.length });
 
         // For PDF with all pages and standard quality, use native PDF printing (vector quality)
         if (this.currentFormat === "pdf" && isAllPages && options.quality === "standard") {

--- a/packages/udoc-viewer/test/browser/download-print-events.test.ts
+++ b/packages/udoc-viewer/test/browser/download-print-events.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { UDocClient } from "../../src/index.js";
+import type { UDocViewer } from "../../src/index.js";
+import sampleUrl from "../fixtures/sample.pdf?url";
+
+let container: HTMLDivElement;
+let client: UDocClient | null = null;
+let viewer: UDocViewer | null = null;
+
+beforeEach(() => {
+    container = document.createElement("div");
+    container.style.width = "800px";
+    container.style.height = "600px";
+    document.body.appendChild(container);
+});
+
+afterEach(() => {
+    viewer?.destroy();
+    viewer = null;
+    client?.destroy();
+    client = null;
+    container.remove();
+});
+
+async function bootstrap(): Promise<UDocViewer> {
+    client = await UDocClient.create({ googleFonts: false, disableUpdateCheck: true });
+    viewer = await client.createViewer({ container });
+    const loaded = new Promise<void>((resolve) => viewer!.on("document:load", () => resolve()));
+    await viewer.load(sampleUrl);
+    await loaded;
+    return viewer;
+}
+
+// Stub HTMLAnchorElement.click so download() doesn't trigger a real browser download.
+async function withStubbedAnchorClick(fn: () => Promise<void>): Promise<void> {
+    const orig = HTMLAnchorElement.prototype.click;
+    HTMLAnchorElement.prototype.click = () => {};
+    try {
+        await fn();
+    } finally {
+        HTMLAnchorElement.prototype.click = orig;
+    }
+}
+
+describe("UDocViewer download/print events", () => {
+    it("emits download with the resolved filename", async () => {
+        const v = await bootstrap();
+        await withStubbedAnchorClick(async () => {
+            const downloaded = new Promise<{ filename: string }>((resolve) => v.on("download", resolve));
+            await v.download("test-output.pdf");
+            expect((await downloaded).filename).toBe("test-output.pdf");
+        });
+    });
+
+    it("falls back to the default filename when none is provided", async () => {
+        const v = await bootstrap();
+        await withStubbedAnchorClick(async () => {
+            const downloaded = new Promise<{ filename: string }>((resolve) => v.on("download", resolve));
+            await v.download();
+            const ev = await downloaded;
+            expect(ev.filename).toMatch(/\.[a-z0-9]+$/i);
+        });
+    });
+
+    it("emits print on print(options) with the resolved page count", async () => {
+        const v = await bootstrap();
+        const printed = new Promise<{ pageCount: number }>((resolve) => v.on("print", resolve));
+        // Fire-and-forget; the event emits before the iframe-based render starts.
+        void v.print({ pageRange: { kind: "all" }, quality: "standard" });
+        expect((await printed).pageCount).toBe(v.pageCount);
+    });
+
+    it("does NOT emit print when print() is called with no args (dialog-only)", async () => {
+        const v = await bootstrap();
+        let fired = false;
+        v.on("print", () => {
+            fired = true;
+        });
+        await v.print();
+        await Promise.resolve();
+        expect(fired).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

The viewer exposes several events, e.g. for page change, but nothing for print and download

## Changes

Adds those events with a bit of metadata

## How to Test

I added a browser test. You can also open the demo page and paste this in:

```js
const v = window.__viewer ?? (await window.client?.createViewer({ container: document.body }));
  v.on("download", e => console.log("DL:", e));
  v.on("print",    e => console.log("PR:", e));
```

Then download and print to see them print to the console.

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] `npm run build` succeeds without errors
- [x] I have tested my changes against the demo app or an example
- [x] My changes do not introduce new warnings or errors in the browser console
