### PR TITLE
fix print button in dark mode

### DIFF
--- a/packages/udoc-viewer/src/ui/viewer/styles.css
+++ b/packages/udoc-viewer/src/ui/viewer/styles.css
@@ -116,7 +116,7 @@
     --udoc-text-label: #aaa;
     --udoc-text-subtle: #a0a0a0;
     --udoc-text-placeholder: #777;
-    --udoc-text-on-primary: #fff;
+    --udoc-text-on-primary: #1a1a1a;
 
     --udoc-primary: #e0e0e0;
     --udoc-primary-hover: #f0f0f0;


### PR DESCRIPTION
## Summary

The print button lacks contrast in dark mode

Before:

<img width="506" height="488" alt="image" src="https://github.com/user-attachments/assets/86d03e3d-686f-4f07-ae7e-9796692abe62" />

After:

<img width="488" height="454" alt="image" src="https://github.com/user-attachments/assets/7576ee1f-753a-400a-8dc4-71baa6a0fb8c" />


## Changes

Just change the CSS var

## How to Test

1. switch to dark mode
2. open the print dialog

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] `npm run build` succeeds without errors
- [x] I have tested my changes against the demo app or an example
- [x] My changes do not introduce new warnings or errors in the browser console
