### PR TITLE
Set search input text color so it follows the theme

### DIFF
--- a/packages/udoc-viewer/src/ui/viewer/styles.css
+++ b/packages/udoc-viewer/src/ui/viewer/styles.css
@@ -3109,6 +3109,7 @@
     font-size: 13px;
     min-width: 0;
     background: transparent;
+    color: var(--udoc-text-heading);
 }
 
 /* Suppress focus ring on the inner input — the wrapper handles :focus-within */


### PR DESCRIPTION
## Summary

Before:

<img width="385" height="201" alt="image" src="https://github.com/user-attachments/assets/11b4b0df-b1b3-411c-a1f7-c7fd0bc63aa0" />


After: 

<img width="371" height="193" alt="image" src="https://github.com/user-attachments/assets/aebce138-df39-49e4-855a-62f9179d864b" />

## Changes

set CSS variable

## How to Test

<!-- Describe how a reviewer can verify your changes. -->

1. switch to dark mode
2. search

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] `npm run build` succeeds without errors
- [x] I have tested my changes against the demo app or an example
- [x] My changes do not introduce new warnings or errors in the browser console
