### PR TITLE
Fix the font tab's behavior

### DIFF
--- a/packages/udoc-viewer-demo/src/main.ts
+++ b/packages/udoc-viewer-demo/src/main.ts
@@ -522,6 +522,7 @@ const OPTION_GROUPS: ToggleGroup[] = [
             { label: "Disable Bookmarks", onChange: (c, v) => v.setPanelEnabled("bookmarks", !c) },
             { label: "Disable Layers", onChange: (c, v) => v.setPanelEnabled("layers", !c) },
             { label: "Disable Attachments", onChange: (c, v) => v.setPanelEnabled("attachments", !c) },
+            { label: "Disable Fonts", onChange: (c, v) => v.setPanelEnabled("fonts", !c) },
         ],
     },
     {

--- a/packages/udoc-viewer/src/ui/viewer/components/LeftPanel.ts
+++ b/packages/udoc-viewer/src/ui/viewer/components/LeftPanel.ts
@@ -1,7 +1,7 @@
 import type { Store } from "../../framework/store";
 import { subscribeSelector } from "../../framework/selectors";
 import type { ViewerState, LeftPanelTab, PanelTab } from "../state";
-import { isLeftPanelTab } from "../state";
+import { isLeftPanelTab, LEFT_PANEL_TABS } from "../state";
 import type { Action } from "../actions";
 import type { WorkerClient } from "../../../worker/index.js";
 import type { I18n } from "../i18n/index.js";
@@ -19,14 +19,16 @@ interface TabConfig {
     icon: string;
 }
 
-const TABS: TabConfig[] = [
-    { id: "thumbnail", label: "Thumbnails", icon: ICON_THUMBNAIL },
-    { id: "outline", label: "Outline", icon: ICON_OUTLINE },
-    { id: "bookmarks", label: "Bookmarks", icon: ICON_BOOKMARK },
-    { id: "layers", label: "Layers", icon: ICON_LAYERS },
-    { id: "attachments", label: "Attachments", icon: ICON_ATTACHMENT },
-    { id: "fonts", label: "Fonts", icon: ICON_FONTS },
-];
+const TAB_PRESENTATION: Record<LeftPanelTab, { label: string; icon: string }> = {
+    thumbnail: { label: "Thumbnails", icon: ICON_THUMBNAIL },
+    outline: { label: "Outline", icon: ICON_OUTLINE },
+    bookmarks: { label: "Bookmarks", icon: ICON_BOOKMARK },
+    layers: { label: "Layers", icon: ICON_LAYERS },
+    attachments: { label: "Attachments", icon: ICON_ATTACHMENT },
+    fonts: { label: "Fonts", icon: ICON_FONTS },
+};
+
+const TABS: TabConfig[] = LEFT_PANEL_TABS.map((id) => ({ id, ...TAB_PRESENTATION[id] }));
 
 type LeftPanelSlice = {
     open: boolean;

--- a/packages/udoc-viewer/src/ui/viewer/components/Toolbar.ts
+++ b/packages/udoc-viewer/src/ui/viewer/components/Toolbar.ts
@@ -2,20 +2,11 @@ import type { Store } from "../../framework/store";
 import { subscribeSelector } from "../../framework/selectors";
 import { on } from "../../framework/events";
 import type { I18n } from "../i18n/index.js";
-import type {
-    ViewerState,
-    ZoomMode,
-    PanelTab,
-    LeftPanelTab,
-    ThemeMode,
-    ActiveTool,
-    ToolKind,
-    DocumentFormat,
-} from "../state";
+import type { ViewerState, ZoomMode, PanelTab, ThemeMode, ActiveTool, ToolKind, DocumentFormat } from "../state";
 
 /** Simple-tool kinds — the subset of `ToolKind` that has no sub-toolbar. */
 type SimpleToolKind = "pointer" | "hand" | "zoom";
-import { isLeftPanelTab, ANNOTATION_FORMATS } from "../state";
+import { isLeftPanelTab, ANNOTATION_FORMATS, LEFT_PANEL_TABS } from "../state";
 import type { Action } from "../actions";
 import { setupRovingTabindex } from "../a11y";
 import {
@@ -59,8 +50,6 @@ function formatZoomPercent(zoom: number): string {
     const percent = Math.round(zoom * 1000) / 10;
     return percent % 1 === 0 ? `${percent}%` : `${percent.toFixed(1)}%`;
 }
-
-const LEFT_TABS: LeftPanelTab[] = ["thumbnail", "outline", "bookmarks", "layers", "attachments"];
 
 interface ToolbarSlice {
     toolbarVisible: boolean;
@@ -576,7 +565,7 @@ export function createToolbar() {
                 return;
             }
             // Find first non-disabled left tab
-            const firstTab = LEFT_TABS.find((t) => !state.disabledPanels.has(t));
+            const firstTab = LEFT_PANEL_TABS.find((t) => !state.disabledPanels.has(t));
             if (firstTab) {
                 store.dispatch({ type: "TOGGLE_PANEL", panel: firstTab });
             }
@@ -775,7 +764,7 @@ export function createToolbar() {
             el.style.display = slice.toolbarVisible ? "" : "none";
 
             // Menu button: hidden when left panel disabled or all left tabs disabled
-            const allLeftDisabled = LEFT_TABS.every((t) => slice.disabledPanels.has(t));
+            const allLeftDisabled = LEFT_PANEL_TABS.every((t) => slice.disabledPanels.has(t));
             menuBtn.style.display = !slice.leftPanelVisible || allLeftDisabled ? "none" : "";
 
             // Search button: hidden when right panel disabled or search individually disabled

--- a/packages/udoc-viewer/src/ui/viewer/state.ts
+++ b/packages/udoc-viewer/src/ui/viewer/state.ts
@@ -40,9 +40,19 @@ export type LeftPanelTab = "thumbnail" | "outline" | "bookmarks" | "layers" | "a
 export type RightPanelTab = "search" | "comments";
 export type PanelTab = LeftPanelTab | RightPanelTab;
 
-const LEFT_TABS: Set<PanelTab> = new Set(["thumbnail", "outline", "bookmarks", "layers", "attachments", "fonts"]);
+/** Canonical render order for the left-panel tab strip. */
+export const LEFT_PANEL_TABS: readonly LeftPanelTab[] = [
+    "thumbnail",
+    "outline",
+    "bookmarks",
+    "layers",
+    "attachments",
+    "fonts",
+];
+
+const LEFT_TABS_SET: ReadonlySet<PanelTab> = new Set(LEFT_PANEL_TABS);
 export function isLeftPanelTab(tab: PanelTab): tab is LeftPanelTab {
-    return LEFT_TABS.has(tab);
+    return LEFT_TABS_SET.has(tab);
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

I added a control to the demo to toggle the font tab, and it behaved poorly, for example, hiding the whole hamburger menu when fonts was the only enabled control.

The root problem was that the `LEFT_TABS` var in Toolbar.ts didn't include `"fonts"` but it was included in `TABS` and the `LEFT_TABS` var in state.ts. I commonized the list, and I refactored the `TABS` var so that the types would it to be exhaustive.

## Changes

- commonized LEFT_TABS
- changed type on TABS
- made sure the inclusion of the "fonts" tab is consistent

## How to Test

1. launch the demo
2. disable all the left tabs except attachments
3. see that it renders as expected

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] `npm run build` succeeds without errors
- [x] I have tested my changes against the demo app or an example
- [x] My changes do not introduce new warnings or errors in the browser console
