### PR TITLE
Hide the left-panel tab strip when only one tab is enabled

### DIFF
--- a/packages/udoc-viewer/src/ui/viewer/components/LeftPanel.ts
+++ b/packages/udoc-viewer/src/ui/viewer/components/LeftPanel.ts
@@ -35,6 +35,7 @@ type LeftPanelSlice = {
     panelVisible: boolean;
     disabledPanels: ReadonlySet<PanelTab>;
     allDisabled: boolean;
+    singleEnabledTab: boolean;
     noTransition: boolean;
 };
 
@@ -105,6 +106,9 @@ export function createLeftPanel() {
         el.style.transition = slice.noTransition ? "none" : "";
 
         el.classList.toggle("udoc-left-panel--closed", !slice.open);
+
+        // Hide the tab strip when there's only one tab to choose between
+        tabBar.style.display = slice.singleEnabledTab ? "none" : "";
 
         // Apply width from state (only when open)
         if (slice.open && slice.width !== null) {
@@ -280,6 +284,7 @@ export function createLeftPanel() {
                 a.panelVisible === b.panelVisible &&
                 a.disabledPanels === b.disabledPanels &&
                 a.allDisabled === b.allDisabled &&
+                a.singleEnabledTab === b.singleEnabledTab &&
                 a.noTransition === b.noTransition,
         });
 
@@ -329,14 +334,15 @@ export function createLeftPanel() {
 function selectLeftPanel(state: ViewerState): LeftPanelSlice {
     const panel = state.activePanel;
     const isLeftTab = panel !== null && isLeftPanelTab(panel);
-    const allDisabled = TABS.every((tab) => state.disabledPanels.has(tab.id));
+    const enabledCount = TABS.reduce((n, tab) => (state.disabledPanels.has(tab.id) ? n : n + 1), 0);
     return {
         open: isLeftTab,
         activeTab: isLeftTab ? panel : null,
         width: state.leftPanelWidth,
         panelVisible: state.leftPanelVisible,
         disabledPanels: state.disabledPanels,
-        allDisabled,
+        allDisabled: enabledCount === 0,
+        singleEnabledTab: enabledCount === 1,
         noTransition: state.panelTransitionsDisabled,
     };
 }


### PR DESCRIPTION
## Summary

Sort of a judgment call. If you disable all but one of the controls in the left tab, the tab strip just wastes space, since there are no alternative options. This PR hides the control if there's only one.

Before:

<img width="832" height="491" alt="image" src="https://github.com/user-attachments/assets/46c71df4-3898-4dbe-936b-ccd4dd394453" />


After:

<img width="852" height="562" alt="image" src="https://github.com/user-attachments/assets/44684b80-ab46-4eec-8a2c-63dcd797aa2e" />

## Related Issue

https://github.com/docMentis/docmentis-udoc-viewer/pull/28

## Changes

- if there's only one left tab, don't show the left tab bar

## How to Test

~This PR kind of depends on https://github.com/docMentis/docmentis-udoc-viewer/pull/28 to work correctly. So if you want to test it without first merging that, test the combined branch, which you can find here: https://github.com/icambron/docmentis-udoc-viewer/tree/preview/sidebar-single-tab~ Edit: updated the PR with the main branch, should work on its own now.

1. open the demo
2. disable every left tab but one
3. open the hamburger menu

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] `npm run build` succeeds without errors
- [x] I have tested my changes against the demo app or an example
- [x] My changes do not introduce new warnings or errors in the browser console
